### PR TITLE
트위터 카드 메타태그 수정

### DIFF
--- a/src/templates/Post.js
+++ b/src/templates/Post.js
@@ -55,8 +55,8 @@ class Post extends React.Component {
                   <meta property="og:description" content={ogDescription} />
                   <meta property="og:image" content={coverImageUrl || defaultOgImageUrl} />
                   <meta property="og:url" content={ogUrl} />
-                  <meta property="twitter:card" content="summary" />
-                  <meta property="twitter:site" content="@adhrinae" />
+                  <meta name="twitter:card" content="summary" />
+                  <meta name="twitter:site" content="@adhrinae" />
                 </Helmet>
                 <div className="post-title">
                   <h1>{title}</h1>


### PR DESCRIPTION
트위터 카드는 OpenGraph와 다르게 meta **name** 어트리뷰트를 쓰더군요.

그런데 트위터 카드 공식 문서에서는 아예 비워두면 OG 메타데이터를 알아서 긁어간다고 합니다.